### PR TITLE
Permit host filesystem access for Thonny

### DIFF
--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -12,6 +12,7 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
+  - --filesystem=host
   - --share=ipc
   - --share=network
   - --socket=x11


### PR DESCRIPTION
This is on par with all of the other IDE and code editor Flatpaks. The sandbox is not the best experience for development and has some limitations. The way the sandbox exposes files is secure, but not ideal for code editors where the path to the file is obscure. It's much easier for things to be mounted where they are expected. Additionally, mounted media needs to be accessible to Thonny, too.

Hopefully this fixes thonny/thonny#2439.