### PR TITLE
Make it possible to install and use Python packages from Thonny

### DIFF
--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -4,7 +4,7 @@ runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-command: thonny
+command: thonny.sh
 cleanup:
   - /man
   - /share/man
@@ -12,7 +12,15 @@ finish-args:
   # Thonny requires access to serial / USB devices for embedded development.
   - --device=all
 
-  - --filesystem=host
+  - --filesystem=/media
+  - --filesystem=/run/media
+
+  # todo Remove filesystem=home permissions when it's possible to open directories with the native file chooser dialog.
+  - --filesystem=home
+  # todo Use --persist=.local to isolate Python packages installed to the user installation of the Flatpak from the user installation on the host.
+  # This should be uncommented when removing --filesystem=home.
+  # - --persist=.local
+
   - --share=ipc
   - --share=network
   - --socket=x11
@@ -251,5 +259,12 @@ modules:
         -Dm644 -T packaging/icons/thonny-$size.png ${FLATPAK_DEST}/share/icons/hicolor/$size/apps/${FLATPAK_ID}.png;
         done
       - install -Dm644 packaging/linux/org.thonny.Thonny.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.appdata.xml
+      - install -Dm 755 -t /app/bin/ thonny.sh
     sources:
       - thonny-sources.yaml
+      - type: script
+        dest-filename: thonny.sh
+        commands:
+          # Set PYTHONUSERBASE to be under the ~/.var/app/org.thonny.Thonny/.local directory.
+          - export PYTHONUSERBASE=$(realpath $XDG_DATA_HOME/../.local)
+          - /app/bin/thonny "$@"


### PR DESCRIPTION
The installation of user packages is isolated inside the Flatpak. This prevents contamination of user installed packages on the host. Filesystem access is now only permitted for the mount directories and the home directory. This allows for accessing mounted media by Thonny, which is necessary, while permitting less access from within the sandbox.

Ideally the Flatpak would not allow access to the home directory directly. Portals should be used, but Thonny doesn't permitting opening entire directories. This means using multiple Python files is extremely difficult when the sandbox is fully in effect. Work upstream in Thonny could make this possible.

Fixes #148 and #130.