### PR TITLE
Allow access to the Udisks D-Bus system bus and add the dbus-next Python package

### DIFF
--- a/bundled-python-modules.json
+++ b/bundled-python-modules.json
@@ -365,6 +365,25 @@
                     "sha256": "4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"
                 }
             ]
+        },
+        {
+            "name": "python3-dbus-next",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-next\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/fc/c0a3f4c4eaa5a22fbef91713474666e13d0ea2a69c84532579490a9f2cc8/dbus_next-0.2.3-py3-none-any.whl",
+                    "sha256": "58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "dbus_next",
+                        "packagetype": "bdist_wheel"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --system-talk-name=org.freedesktop.UDisks2
 modules:
   # The `tkinter` module is missing from the Freedesktop Sdk's Python installation.
   - name: tkinter


### PR DESCRIPTION
This PR is intended for PR thonny/thonny#2683. After this PR is merged and the next release of Thonny is available, this PR should be merged to allow access to the Udisks D-Bus system bus in order to access available filesystems in order to allow users to access connected Microcontrollers. This PR also adds the necessary Python package used to access D-Bus, [dbus-next](https://github.com/altdesktop/python-dbus-next).

Fixes #153 