### PR TITLE
Add the missing turtle module to the Python installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ I usually convert these to YAML and place them directly in the Flatpak manifest 
     git -C thonny checkout "$thonny_commit"
     python3 flatpak-builder-tools/pip/flatpak-pip-generator --runtime org.freedesktop.Sdk//23.08 -r thonny/packaging/requirements-regular-bundle.txt -o bundled-python-modules --checker-data
 
-If you have `org.freedesktop.Sdk//22.08` installed in *both* the user and system installations, the Flatpak Pip Generator will choke generating the manifest.
+If you have `org.freedesktop.Sdk//23.08` installed in *both* the user and system installations, the Flatpak Pip Generator will choke generating the manifest.
 The best option at the moment is to temporarily remove either the user or the system installation until this issue is fixed upstream.
 
 #### bcrypt and cryptography

--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -73,6 +73,18 @@ modules:
               stable-only: true
               url-template: https://prdownloads.sourceforge.net/tcl/tk$version-src.tar.gz
 
+  # Add back the Turtle Python module which is stripped out of the org.freedesktop.Sdk.
+  # Be sure to use the turtle module from the same version of Python that's in the org.freedesktop.Sdk.
+  # Update when updating runtime-version.
+  - name: python3-turtle
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 turtle.py ${FLATPAK_DEST}/lib/python3.11/site-packages/turtle.py
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/python/cpython/v3.11.6/Lib/turtle.py
+        sha256: 787af385d6d4417aac8b686e8d5f49ce4afd7d1d09bde685bb378ed6ecc4fb7d
+
   # Python dependencies required to build things
   - name: python3-toml
     buildsystem: simple


### PR DESCRIPTION
The org.freedesktop.Sdk strips out the built-in `turtle` Python module. For Thonny, users expect this module to be available. This PR installs the missing `turtle` module.

Fixes thonny/thonny#2969.