### PR TITLE
Apply a patch to fix venv creation in the Flatpak

### DIFF
--- a/0002-Create-venv-and-install-pip-in-venv-as-separate-step.patch
+++ b/0002-Create-venv-and-install-pip-in-venv-as-separate-step.patch
@@ -1,0 +1,44 @@
+From ad5d9977f3d7daaca79cab9b4f91f0c4f78af12c Mon Sep 17 00:00:00 2001
+From: Jordan Williams <jordan@jwillikers.com>
+Date: Sat, 16 Mar 2024 11:43:26 -0500
+Subject: [PATCH] Create venv and install pip in venv as separate steps
+
+---
+ thonny/plugins/cpython_frontend/cp_front.py | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/thonny/plugins/cpython_frontend/cp_front.py b/thonny/plugins/cpython_frontend/cp_front.py
+index d7d4f0aa..8c8f1b35 100644
+--- a/thonny/plugins/cpython_frontend/cp_front.py
++++ b/thonny/plugins/cpython_frontend/cp_front.py
+@@ -338,7 +338,7 @@ class LocalCPythonConfigurationPage(BackendDetailsConfigPage):
+         path = normpath_with_actual_case(path)
+ 
+         proc = subprocess.Popen(
+-            [running.get_front_interpreter_for_subprocess(), "-m", "venv", path],
++            [running.get_front_interpreter_for_subprocess(), "-m", "venv", "--without-pip", path],
+             stdin=None,
+             stdout=subprocess.PIPE,
+             stderr=subprocess.STDOUT,
+@@ -355,6 +355,18 @@ class LocalCPythonConfigurationPage(BackendDetailsConfigPage):
+             exe_path = os.path.join(path, "bin", "python3")
+ 
+         if os.path.exists(exe_path):
++            proc = subprocess.Popen(
++                [exe_path, "-m", "ensurepip", "--default-pip", "--upgrade"],
++                stdin=None,
++                stdout=subprocess.PIPE,
++                stderr=subprocess.STDOUT,
++                universal_newlines=True,
++            )
++            from thonny.workdlg import SubprocessDialog
++
++            dlg = SubprocessDialog(self, proc, tr("Initializing virtual environment"), autostart=True)
++            ui_utils.show_dialog(dlg)
++
+             self._configuration_variable.set(exe_path)
+ 
+     def should_restart(self):
+-- 
+2.44.0
+

--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -17,9 +17,6 @@ finish-args:
 
   # todo Remove filesystem=home permissions when it's possible to open directories with the native file chooser dialog.
   - --filesystem=home
-  # todo Use --persist=.local to isolate Python packages installed to the user installation of the Flatpak from the user installation on the host.
-  # This should be uncommented when removing --filesystem=home.
-  # - --persist=.local
 
   - --share=ipc
   - --share=network
@@ -270,6 +267,6 @@ modules:
       - type: script
         dest-filename: thonny.sh
         commands:
-          # Set PYTHONUSERBASE to be under the ~/.var/app/org.thonny.Thonny/.local directory.
-          - export PYTHONUSERBASE=$(realpath $XDG_DATA_HOME/../.local)
+          # Set PYTHONUSERBASE to be under the ~/.var/app/org.thonny.Thonny/data directory.
+          - export PYTHONUSERBASE=$XDG_DATA_HOME
           - /app/bin/thonny "$@"

--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -265,6 +265,8 @@ modules:
       - thonny-sources.yaml
       - type: patch
         path: 0001-Update-appstream-metadata-3098.patch
+      - type: patch
+        path: 0002-Create-venv-and-install-pip-in-venv-as-separate-step.patch
       - type: script
         dest-filename: thonny.sh
         commands:


### PR DESCRIPTION
Addresses part of the problem that appeared in #259.

Don't use realpath to determine the PYTHONUSERBASE directory. Just use the `XDG_DATA_HOME` directory directly for Python packages installed via pip.