### PR TITLE
Workaround UTF-8 encoding issue in Tcl

### DIFF
--- a/org.thonny.Thonny.yaml
+++ b/org.thonny.Thonny.yaml
@@ -38,6 +38,9 @@ modules:
         subdir: unix
         post-install:
           - chmod +w ${FLATPAK_DEST}/lib/libtcl*.so
+        build-options: &tcl-build-options
+          # Workaround UTF-8 encoding issue in Tcl < 9
+          cflags: -DTCL_UTF_MAX=4
         cleanup:
           - /bin
           - /lib/pkgconfig
@@ -59,6 +62,7 @@ modules:
         post-install:
           # libtcl*tk*.so in Tk 9
           - chmod +w ${FLATPAK_DEST}/lib/libtk*.so
+        build-options: *tcl-build-options
         cleanup:
           - /bin
           - /lib/pkgconfig


### PR DESCRIPTION
When performing case-insensitive search, a Unicode character ≥ 0x10000 causes the program to crash. This fix provides a workaround for this specific scenario.

See https://github.com/thonny/thonny/issues/2996#issuecomment-2499400372